### PR TITLE
Fix RSS feed title escaping and author display

### DIFF
--- a/wiki/feeds.py
+++ b/wiki/feeds.py
@@ -21,10 +21,8 @@ class WikiFeed(Feed):
         return "%s" % obj.text
         
     def item_author_name(self, obj):
-        return "%s" % obj.author.username
-        
-    def item_author_email(self,obj):
-        return "%s" % obj.author.email
+        full_name = obj.author.get_full_name()
+        return full_name or obj.author.username
 
     def item_pubdate(self, obj):
         return obj.pubdate

--- a/wiki/templates/feeds/title.html
+++ b/wiki/templates/feeds/title.html
@@ -1,1 +1,1 @@
-{{ obj.title }}
+{% autoescape off %}{{ obj.title }}{% endautoescape %}


### PR DESCRIPTION
## Summary
- Disable autoescape in `wiki/templates/feeds/title.html` so titles with apostrophes/quotes aren't double-escaped (Feedly was showing `UK&#x27;s NHS` instead of `UK's NHS`).
- Drop `item_author_email` and return the user's full name from `item_author_name` in `wiki/feeds.py`, so the feed emits `<dc:creator>Alcides Fonseca</dc:creator>` instead of `<author>me@alcidesfonseca.com (alcides)</author>`.

## Test plan
- [ ] Load `/feeds/en/` (and `/feeds/pt/`, `/feeds/`) and confirm titles like "UK's NHS just got called…" render with a real apostrophe, not `&#x27;`.
- [ ] Confirm the author shows as the full name in Feedly (requires `first_name`/`last_name` set on the User in Django admin; otherwise falls back to username).
- [ ] Verify the feed XML still validates (e.g. via the W3C feed validator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)